### PR TITLE
#5: Docker Authorization Fix 1.

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
There's an error in the current iteration of the `Publish-Docker-Image` workflow job: 
![image](https://github.com/atomic-works/docker-image-alpine-linux/assets/12419195/4b381cf6-4092-44b7-a88f-b20c5bc85d98)

`atomic-works` is the owner of this repository so I don't understand this error. The documentation for `docker/login-action` recommends authenticating with `github.actor` instead of `github.repository_owner` so this is an attempt to use that. Link [here](https://github.com/docker/login-action#github-container-registry).